### PR TITLE
Fix handling of activeOnly on ValueSet $expand

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -9,7 +9,7 @@
            ca.uhn.hapi.fhir/hapi-fhir-server        {:mvn/version "6.4.4"}
            ca.uhn.hapi.fhir/hapi-fhir-structures-r4 {:mvn/version "6.4.4"}
 
-           com.eldrix/hermes                        {:mvn/version "1.2.1108"}
+           com.eldrix/hermes                        {:mvn/version "1.3.1232"}
            io.pedestal/pedestal.jetty               {:mvn/version "0.5.10"}}
 
  :aliases {:build {:deps       {io.github.clojure/tools.build          {:git/tag "v0.9.4" :git/sha "76b78fe"}

--- a/src/com/eldrix/hades/core.clj
+++ b/src/com/eldrix/hades/core.clj
@@ -127,7 +127,7 @@
     (log/debug "valueset/$expand:" {:url url :filter param-filter :activeOnly activeOnly :displayLanguage displayLanguage})
     (when-let [constraint (convert/parse-implicit-value-set (.getValue url))]
       (let [results (hermes/search svc (cond-> {:constraint (:ecl constraint)
-                                                :inactive-concepts? (convert/parse-fhir-boolean activeOnly :default true :strict true)}
+                                                :inactive-concepts? (not (and activeOnly (convert/parse-fhir-boolean (.getValue activeOnly) :default false :strict true)))}
                                                param-filter (assoc :s (.getValue param-filter))))
             components (map convert/result->vs-component results)]
         (doto (ValueSet.)


### PR DESCRIPTION
Hello! I've been exploring FHIR services and found hades and hermes to be quite interesting. Wanted to help fix what seems to be a bug.

Issue: An exception is thrown when `activeOnly` is provided on `$expand`. Also, I suspect that the way the `activeOnly` parameter is mapped to hermes `:inactive-concepts?` is wrong; those seem like inverses of each other.

In this change, I...
* Do not error when activeOnly is provided
* Fix false equivalence between :inactive-concepts? and activeOnly
* Preserve current default behavior of activeOnly = false
* had to bump hermes to resolve a lmdb version conflict

Cheers